### PR TITLE
fix: pass MCP server configs to Copilot sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,11 @@ CLI_PORT=
 # Cron scheduler (set to true to enable scheduled tasks from cron.json)
 CRON_ENABLED=false
 
+# MCP server configuration file path (optional)
+# Defaults to ./mcp-servers.json if not set
+# Supports native Copilot format: { "mcpServers": { ... } }
+MCP_CONFIG_PATH=
+
 # Bridge mode: "standalone" disables the Copilot CLI extensions (telegram-bridge,
 # cron-scheduler) so the standalone service handles everything. Leave unset or
 # blank for local dev with extensions.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,242 @@
+# Copilot Instructions — Copilot Telegram Bridge
+
+## Project Overview
+
+Multi-channel bridge service connecting Telegram and Slack to GitHub Copilot CLI sessions via the `@github/copilot-sdk`. Each messaging platform runs as a pluggable adapter with its own `SessionManager` managing Copilot session lifecycles.
+
+## Architecture
+
+```
+index.ts (entry)
+├── TelegramAdapter (MessagingChannel)
+│   ├── TelegramPoller → long polling with backoff
+│   ├── CommandHandler → /start, /new, /switch, /list, /end, /status, /help
+│   ├── MessageRouter → text/photo → session
+│   └── SessionManager → CopilotClient ↔ Copilot CLI
+├── SlackAdapter (MessagingChannel)
+│   ├── SlackClient → Socket Mode + Web API
+│   ├── SlackThreadRouter → each thread = one session
+│   ├── SlackCommandHandler → slash commands
+│   └── SessionManager → CopilotClient ↔ Copilot CLI
+└── CronScheduler
+    └── cron.json → hot-reload, sendToCronSession()
+```
+
+### Key Abstractions
+
+- **`MessagingChannel`** (`channels/types.ts`) — Interface all adapters implement: `sendMessage()`, `sendTypingAction()`, `start()`, `stop()`.
+- **`SessionManager`** (`sessions/manager.ts`) — Core state machine. One per channel. Manages `CopilotClient` lifecycle, per-chat session tracking, typing indicators, and per-chat mutex locks.
+- **`Config`** (`config.ts`) — Zod-validated runtime config from `.env` + env vars. Includes MCP server configs loaded from JSON files.
+
+### Session IDs
+
+- User sessions: `tg-{chatId}-{timestamp}`
+- Cron sessions: `cron-{jobId}` (predictable, reusable)
+- Slack sessions: `slack-{channel}-{thread_ts}`
+
+### MCP Server Configuration
+
+Sessions receive MCP tool configs via `mcpServers` on `createSession()`/`resumeSession()`. Resolution priority:
+
+1. `MCP_CONFIG_PATH` env var (explicit path)
+2. `./mcp-servers.json` (project-local)
+3. `~/.copilot/mcp-config.json` (native Copilot config)
+
+Supports both `{ "mcpServers": { ... } }` wrapper and flat format.
+
+## TypeScript & Module System
+
+- **ESM** — `"type": "module"` in package.json. Always use `.js` extensions in relative imports.
+- **Target**: ES2022, `"module": "Node16"`, `"moduleResolution": "Node16"`
+- **Strict mode**: All strict flags enabled (`noImplicitAny`, `strictNullChecks`, etc.)
+- **No DOM** — `"lib": ["ES2022"]`, pure Node.js
+- Native `fetch()` — no external HTTP client for Telegram API
+
+```typescript
+// ✅ Correct import
+import { SessionManager } from "../sessions/manager.js";
+
+// ❌ Wrong — missing .js extension
+import { SessionManager } from "../sessions/manager";
+```
+
+## Naming Conventions
+
+- **Files**: `camelCase.ts` (e.g., `manager.ts`, `adapter.ts`, `thread-router.ts`)
+- **Test files**: `*.test.ts` colocated with source (e.g., `config.test.ts`)
+- **Type-only files**: `types.ts` in each module directory
+- **Classes**: PascalCase (`SessionManager`, `TelegramApi`, `CronScheduler`)
+- **Functions**: camelCase (`loadConfig`, `loadMcpServers`, `cronMatches`)
+- **Constants**: UPPER_SNAKE_CASE (`TELEGRAM_MAX_LENGTH`, `CROSS_SESSION_CONTEXT`)
+- **Session IDs**: kebab-prefixed (`tg-`, `cron-`, `slack-`)
+
+## Error Handling Patterns
+
+### Try-catch with logging and user notification
+
+```typescript
+try {
+  await this.sessionManager.sendMessage(chatId, prompt);
+} catch (err) {
+  console.error("[router] Failed:", err);
+  try {
+    await telegram.sendMessage(chatId, "⚠️ Something went wrong. Please try again.");
+  } catch (notifyErr) {
+    console.warn("[router] Notification failed:", notifyErr);
+  }
+}
+```
+
+### Fire-and-forget with `.catch()` for non-critical operations
+
+```typescript
+this.channel.sendTypingAction(chatId).catch((err) => {
+  console.warn("[session-manager] Typing action failed:", err);
+});
+```
+
+### Zod for config validation
+
+```typescript
+const parsed = configSchema.parse(raw); // Throws ZodError if invalid
+```
+
+### Always clean up on failure — use `finally` blocks for state cleanup
+
+```typescript
+try {
+  await session.disconnect();
+} catch (disconnectErr) {
+  console.warn(`[session-manager] Error disconnecting:`, disconnectErr);
+} finally {
+  this.sessionMap.delete(sessionId);
+  this.attachedSessions.delete(sessionId);
+}
+```
+
+## Concurrency Pattern — Per-Chat Mutex
+
+The `SessionManager` uses a promise-based lock to prevent concurrent session creation per chat:
+
+```typescript
+const prevLock = this.sendLocks.get(chatId) ?? Promise.resolve();
+let releaseLock: () => void;
+const lockPromise = new Promise<void>((resolve) => { releaseLock = resolve; });
+this.sendLocks.set(chatId, lockPromise);
+await prevLock;
+try { /* work */ } finally { releaseLock!(); }
+```
+
+Always use this pattern when adding new operations that could race with session creation.
+
+## Logging Convention
+
+All log messages use `[module-name]` prefix with emoji indicators:
+
+```typescript
+console.log("[config] Configuration loaded");
+console.log("[session-manager] Created session tg-123-1704067200000");
+console.log("[telegram] 🤖 Telegram poller started");
+console.warn("[poller] ⚠️ Telegram API conflict, backing off");
+console.error("[bridge] ❌ Error stopping:", err);
+```
+
+## Testing
+
+### Framework & Commands
+
+- **Vitest** with `vitest.config.ts`
+- Tests colocated: `src/**/*.test.ts`
+
+```bash
+npm test              # vitest run (single pass)
+npm run test:watch    # vitest (watch mode)
+npm run test:coverage # vitest run --coverage
+```
+
+### Coverage Thresholds (enforced)
+
+- Statements: 80%, Branches: 75%, Functions: 80%, Lines: 80%
+- `src/index.ts` excluded from coverage (entry point bootstrapping)
+
+### Test Patterns
+
+- Use `vi.mock()` for module-level mocks (e.g., `@github/copilot-sdk`, `node:os`)
+- Use `vi.fn()` for per-test spies
+- Use temp directories (`tmpdir()`) for filesystem tests — clean up in `afterEach`
+- Clear env vars in `beforeEach` to prevent cross-test contamination
+- Mock `CopilotClient` with a `MockSession` class that supports `on()`, `emit()`, `send()`, `disconnect()`
+
+### Writing Tests for New Features
+
+Every source change must have corresponding tests. When adding:
+
+- **New config fields** — test loading from `.env`, from env vars, defaults, validation errors
+- **New SessionManager methods** — test all code paths (create, resume, resume-fallback-to-create, switchSession)
+- **New commands** — test routing, success, and error paths
+- **New adapters** — test the `MessagingChannel` interface contract
+
+## Build
+
+```bash
+npm run build   # tsc → dist/
+npm start       # node dist/index.js
+npm run dev     # tsc --watch & node --watch dist/index.js
+```
+
+Output goes to `dist/` with declarations (`.d.ts`) and source maps.
+
+## Adding a Telegram Command
+
+1. Add a case to `telegram/commands.ts` → `handle()` switch
+2. Implement `handleMyCommand(chatId, args)` with try/catch + user feedback
+3. Add tests in `telegram/commands.test.ts`
+4. Update the `/help` response text
+
+## Adding a Cron Job
+
+Edit `cron.json` (hot-reloaded via file watcher):
+
+```json
+{
+  "id": "my-job",
+  "schedule": "0 9 * * 1-5",
+  "prompt": "Your prompt here",
+  "enabled": true,
+  "channel": "telegram"
+}
+```
+
+Cron sessions run in isolated `cron-{jobId}` sessions — they never switch the user's active session.
+
+## Infrastructure & Deployment
+
+- **Terraform** in `infra/aws/` — EC2 + OpenShell sandbox
+- **Commit-pinned deploys** — `TF_VAR_git_ref` = `GITHUB_SHA`
+- **GitHub Actions** (`.github/workflows/deploy.yml`) — PR → dev, merge to main → prod
+- **OpenShell sandbox** — default-deny networking, credential injection via providers
+- **MCP config** generated at `~/.copilot/mcp-config.json` by `sandbox-setup.sh`
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `TELEGRAM_BOT_TOKEN` | One channel required | Telegram bot token from @BotFather |
+| `TELEGRAM_CHAT_ID` | No | Restrict to specific chat |
+| `SLACK_BOT_TOKEN` | One channel required | Slack bot token (xoxb-...) |
+| `SLACK_APP_TOKEN` | With Slack | Slack app-level token (xapp-...) |
+| `SLACK_CHANNEL_ID` | No | Restrict to specific channel |
+| `CLI_URL` | No | Connect to existing Copilot CLI server |
+| `CLI_PORT` | No | Port for CLI server connection |
+| `CRON_ENABLED` | No | Enable cron scheduler (default: false) |
+| `MCP_CONFIG_PATH` | No | Path to MCP server config JSON |
+| `LOG_LEVEL` | No | debug, info, warn, error (default: info) |
+
+## Gotchas
+
+- **Telegram poller conflict**: Only one poller per bot token. Multiple instances → 409 Conflict → 3s backoff.
+- **ESM imports**: Always use `.js` extension in relative imports even though source is `.ts`.
+- **Session event handlers**: Use `attachedSessions` Set to prevent double-attaching handlers on resume.
+- **Infinite sessions**: Enabled by default with 80% background compaction / 95% buffer exhaustion thresholds.
+- **Slack chat IDs**: Format is `{channel}:{thread_ts}`, not just channel ID.
+- **Config changes require restart**: MCP servers and env config are loaded once at startup.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,6 +44,71 @@ Sessions receive MCP tool configs via `mcpServers` on `createSession()`/`resumeS
 
 Supports both `{ "mcpServers": { ... } }` wrapper and flat format.
 
+### Extension vs Service Mode (BRIDGE_MODE)
+
+This repo operates in two modes. **Do not remove extensions** — they are kept for local dev.
+
+- **Extension mode** (local dev) — Run `copilot --experimental` in this repo. Extensions in `.github/extensions/` auto-load: `telegram-bridge`, `cron-scheduler`, `ci-monitor`. The bridge runs inside a single Copilot session.
+- **Service mode** (cloud/standalone) — `npm start` runs the `CopilotClient` SDK service. Extensions load but stay idle because `BRIDGE_MODE=standalone` is set. The service manages N sessions programmatically.
+
+The `BRIDGE_MODE` env var controls this:
+- `BRIDGE_MODE=standalone` → extensions detect this and skip activation
+- `BRIDGE_MODE` unset → extensions run normally (local dev)
+
+`sandbox-setup.sh` sets `BRIDGE_MODE=standalone` automatically in the deployed `.env`.
+
+### Message Flow (Telegram → Copilot → Telegram)
+
+```
+User sends Telegram message
+  → TelegramPoller receives via getUpdates
+  → MessageRouter calls sessionManager.sendMessage(chatId, text)
+  → SessionManager calls session.send({ prompt, mode: "enqueue" })
+  → CopilotClient processes prompt, agent runs tools
+  → session emits "assistant.message" event
+  → SessionManager forwards via channel.sendMessage(chatId, content)
+  → TelegramApi sends response to user
+```
+
+### session.send() Modes — CRITICAL
+
+The CopilotClient SDK's `session.send()` has different modes. Using the wrong one is a common mistake:
+
+- **`mode: "enqueue"`** — Queues the message. If the agent is busy, it processes after the current turn. Use for **user messages from the bridge** and **cron job prompts**.
+- **`mode: "immediate"`** — Steers the agent mid-turn, interrupting current work. Use for **CI notifications**, **system alerts**, and anything in `.github/extensions/` that needs to inject context while the agent is running.
+
+**Wrong:** Using `enqueue` for CI results (they queue behind the current turn and feel delayed).
+**Wrong:** Using `immediate` for normal user messages (can interrupt agent mid-thought).
+
+### Telegram Poller — Singleton Constraint
+
+Telegram's `getUpdates` API allows **only one consumer per bot token**. Multiple pollers → HTTP 409 "Conflict" error.
+
+- The `TelegramPoller` handles this with a 3-second backoff on conflict detection
+- **Never start a second poller** for the same bot token — in extension mode, check if polling is already active before starting
+- In service mode, only one `TelegramAdapter` instance exists per bot token (enforced by the single-process architecture)
+- For local dev + cloud simultaneously, use **separate bot tokens** (one for local, one for the deployed instance)
+
+## Git & CI Workflow
+
+### Pushing Code
+
+**Always use `gh hookflow git-push`** instead of raw `git push`. Direct pushes are blocked by hookflow governance:
+
+```bash
+# ✅ Correct
+gh hookflow git-push origin my-branch
+
+# ❌ Blocked — will be denied
+git push origin my-branch
+```
+
+### CI/CD
+
+- PRs trigger deploy to `dev` environment
+- Merges to `main` trigger deploy to `prod`
+- CI status is reported by the `ci-monitor` extension (when loaded) via `mode: "immediate"`
+
 ## TypeScript & Module System
 
 - **ESM** — `"type": "module"` in package.json. Always use `.js` extensions in relative imports.
@@ -216,6 +281,7 @@ Cron sessions run in isolated `cron-{jobId}` sessions — they never switch the 
 - **GitHub Actions** (`.github/workflows/deploy.yml`) — PR → dev, merge to main → prod
 - **OpenShell sandbox** — default-deny networking, credential injection via providers
 - **MCP config** generated at `~/.copilot/mcp-config.json` by `sandbox-setup.sh`
+- **BRIDGE_MODE** set to `standalone` by `sandbox-setup.sh` to disable extensions in service mode
 
 ## Environment Variables
 
@@ -230,11 +296,15 @@ Cron sessions run in isolated `cron-{jobId}` sessions — they never switch the 
 | `CLI_PORT` | No | Port for CLI server connection |
 | `CRON_ENABLED` | No | Enable cron scheduler (default: false) |
 | `MCP_CONFIG_PATH` | No | Path to MCP server config JSON |
+| `BRIDGE_MODE` | No | Set to `standalone` in cloud to disable extensions |
 | `LOG_LEVEL` | No | debug, info, warn, error (default: info) |
 
 ## Gotchas
 
-- **Telegram poller conflict**: Only one poller per bot token. Multiple instances → 409 Conflict → 3s backoff.
+- **`git push` is blocked** — Use `gh hookflow git-push origin branch` instead. Direct `git push` is denied by hookflow governance.
+- **`session.send()` mode matters** — `enqueue` for user messages, `immediate` for CI/system notifications. Using the wrong mode causes delayed or disruptive behavior.
+- **Telegram poller conflict**: Only one poller per bot token. Multiple instances → 409 Conflict → 3s backoff. Use separate bot tokens for local dev + cloud.
+- **Don't remove extensions** — Set `BRIDGE_MODE=standalone` to disable them in service mode. They're needed for local dev with `copilot --experimental`.
 - **ESM imports**: Always use `.js` extension in relative imports even though source is `.ts`.
 - **Session event handlers**: Use `attachedSessions` Set to prevent double-attaching handlers on resume.
 - **Infinite sessions**: Enabled by default with 80% background compaction / 95% buffer exhaustion thresholds.

--- a/mcp-servers.json.example
+++ b/mcp-servers.json.example
@@ -1,0 +1,32 @@
+{
+  "mcpServers": {
+    "exa": {
+      "tools": ["*"],
+      "type": "http",
+      "url": "https://mcp.exa.ai/mcp?exaApiKey=YOUR_EXA_API_KEY"
+    },
+    "mslearn": {
+      "tools": ["*"],
+      "type": "http",
+      "url": "https://learn.microsoft.com/api/mcp"
+    },
+    "perplexity": {
+      "tools": ["*"],
+      "type": "local",
+      "command": "npx",
+      "args": ["-y", "perplexity-mcp"],
+      "env": {
+        "PERPLEXITY_API_KEY": "YOUR_PERPLEXITY_API_KEY"
+      }
+    },
+    "youtube": {
+      "tools": ["*"],
+      "type": "local",
+      "command": "npx",
+      "args": ["-y", "@htekdev/youtube-mcp-server"],
+      "env": {
+        "YOUTUBE_API_KEY": "YOUR_YOUTUBE_API_KEY"
+      }
+    }
+  }
+}

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { loadConfig } from "./config.js";
+import { loadConfig, loadMcpServers } from "./config.js";
 import { writeFileSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -17,6 +17,7 @@ describe("loadConfig", () => {
     delete process.env.CLI_PORT;
     delete process.env.CRON_ENABLED;
     delete process.env.LOG_LEVEL;
+    delete process.env.MCP_CONFIG_PATH;
   });
 
   afterEach(() => {
@@ -96,5 +97,124 @@ describe("loadConfig", () => {
 
     const config = loadConfig(testDir);
     expect(config.cliPort).toBe(4321);
+  });
+
+  it("loads MCP servers from mcp-servers.json when present", () => {
+    writeFileSync(join(testDir, ".env"), "TELEGRAM_BOT_TOKEN=token\n");
+    writeFileSync(
+      join(testDir, "mcp-servers.json"),
+      JSON.stringify({
+        mcpServers: {
+          exa: { tools: ["*"], type: "http", url: "https://mcp.exa.ai/mcp" },
+        },
+      }),
+    );
+
+    const config = loadConfig(testDir);
+    expect(config.mcpServers).toEqual({
+      exa: { tools: ["*"], type: "http", url: "https://mcp.exa.ai/mcp" },
+    });
+  });
+
+  it("returns empty mcpServers when no MCP config file exists", () => {
+    writeFileSync(join(testDir, ".env"), "TELEGRAM_BOT_TOKEN=token\n");
+
+    const config = loadConfig(testDir);
+    expect(config.mcpServers).toEqual({});
+  });
+
+  it("loads MCP servers from custom path via MCP_CONFIG_PATH", () => {
+    const customDir = join(testDir, "custom");
+    mkdirSync(customDir, { recursive: true });
+    const customPath = join(customDir, "my-mcp.json");
+    writeFileSync(
+      customPath,
+      JSON.stringify({
+        mcpServers: {
+          mslearn: { tools: ["*"], type: "http", url: "https://learn.microsoft.com/api/mcp" },
+        },
+      }),
+    );
+    writeFileSync(
+      join(testDir, ".env"),
+      `TELEGRAM_BOT_TOKEN=token\nMCP_CONFIG_PATH=${customPath}\n`,
+    );
+
+    const config = loadConfig(testDir);
+    expect(config.mcpServers).toEqual({
+      mslearn: { tools: ["*"], type: "http", url: "https://learn.microsoft.com/api/mcp" },
+    });
+  });
+});
+
+describe("loadMcpServers", () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `mcp-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it("returns empty object for missing file", () => {
+    const result = loadMcpServers(join(testDir, "nonexistent.json"));
+    expect(result).toEqual({});
+  });
+
+  it("parses native Copilot format with mcpServers wrapper", () => {
+    const configPath = join(testDir, "mcp.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        mcpServers: {
+          exa: { tools: ["*"], type: "http", url: "https://mcp.exa.ai/mcp" },
+          perplexity: {
+            tools: ["*"],
+            type: "local",
+            command: "npx",
+            args: ["-y", "perplexity-mcp"],
+            env: { PERPLEXITY_API_KEY: "test-key" },
+          },
+        },
+      }),
+    );
+
+    const result = loadMcpServers(configPath);
+    expect(Object.keys(result)).toEqual(["exa", "perplexity"]);
+    expect(result.exa).toEqual({ tools: ["*"], type: "http", url: "https://mcp.exa.ai/mcp" });
+    expect(result.perplexity).toMatchObject({
+      command: "npx",
+      args: ["-y", "perplexity-mcp"],
+    });
+  });
+
+  it("parses flat format without mcpServers wrapper", () => {
+    const configPath = join(testDir, "mcp.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        exa: { tools: ["*"], type: "http", url: "https://mcp.exa.ai/mcp" },
+      }),
+    );
+
+    const result = loadMcpServers(configPath);
+    expect(result.exa).toEqual({ tools: ["*"], type: "http", url: "https://mcp.exa.ai/mcp" });
+  });
+
+  it("throws on invalid JSON", () => {
+    const configPath = join(testDir, "bad.json");
+    writeFileSync(configPath, "not valid json {{{");
+
+    expect(() => loadMcpServers(configPath)).toThrow("Failed to parse MCP config");
+  });
+
+  it("throws on non-object JSON", () => {
+    const configPath = join(testDir, "array.json");
+    writeFileSync(configPath, "[]");
+
+    expect(() => loadMcpServers(configPath)).toThrow("must be a JSON object");
   });
 });

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -4,6 +4,15 @@ import { writeFileSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
+// Mock homedir so native fallback doesn't pick up the real ~/.copilot/mcp-config.json
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return {
+    ...actual,
+    homedir: vi.fn(() => join(actual.tmpdir(), "fake-home-" + process.pid)),
+  };
+});
+
 describe("loadConfig", () => {
   let testDir: string;
 
@@ -144,6 +153,28 @@ describe("loadConfig", () => {
     expect(config.mcpServers).toEqual({
       mslearn: { tools: ["*"], type: "http", url: "https://learn.microsoft.com/api/mcp" },
     });
+  });
+
+  it("falls back to native ~/.copilot/mcp-config.json when no local config exists", async () => {
+    const { homedir } = await import("node:os");
+    const fakeHome = homedir();
+    mkdirSync(join(fakeHome, ".copilot"), { recursive: true });
+    writeFileSync(
+      join(fakeHome, ".copilot", "mcp-config.json"),
+      JSON.stringify({
+        mcpServers: {
+          exa: { tools: ["*"], type: "http", url: "https://mcp.exa.ai/mcp" },
+        },
+      }),
+    );
+    writeFileSync(join(testDir, ".env"), "TELEGRAM_BOT_TOKEN=token\n");
+
+    const config = loadConfig(testDir);
+    expect(config.mcpServers).toEqual({
+      exa: { tools: ["*"], type: "http", url: "https://mcp.exa.ai/mcp" },
+    });
+
+    rmSync(fakeHome, { recursive: true, force: true });
   });
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import { readFileSync, existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { resolve, join } from "node:path";
+import { homedir } from "node:os";
 import { z } from "zod";
 
 const configSchema = z.object({
@@ -130,9 +131,15 @@ export function loadConfig(cwd: string = process.cwd()): Config {
   }
 
   // Load MCP server configs from file
-  const mcpPath = parsed.mcpConfigPath
-    ? resolve(cwd, parsed.mcpConfigPath)
-    : resolve(cwd, "mcp-servers.json");
+  // Priority: MCP_CONFIG_PATH > ./mcp-servers.json > ~/.copilot/mcp-config.json
+  let mcpPath: string;
+  if (parsed.mcpConfigPath) {
+    mcpPath = resolve(cwd, parsed.mcpConfigPath);
+  } else {
+    const localPath = resolve(cwd, "mcp-servers.json");
+    const nativePath = join(homedir(), ".copilot", "mcp-config.json");
+    mcpPath = existsSync(localPath) ? localPath : nativePath;
+  }
   const mcpServers = loadMcpServers(mcpPath);
 
   const serverCount = Object.keys(mcpServers).length;

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,10 +12,34 @@ const configSchema = z.object({
   cliPort: z.coerce.number().int().positive().optional(),
   cronEnabled: z.boolean().default(false),
   logLevel: z.enum(["debug", "info", "warn", "error"]).default("info"),
+  mcpConfigPath: z.string().optional(),
 });
 
+/** MCP server configuration types matching the CopilotClient SDK. */
+export interface MCPLocalServerConfig {
+  type?: "local" | "stdio";
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+  tools: string[];
+  timeout?: number;
+}
+
+export interface MCPRemoteServerConfig {
+  type: "http" | "sse";
+  url: string;
+  headers?: Record<string, string>;
+  tools: string[];
+  timeout?: number;
+}
+
+export type MCPServerConfig = MCPLocalServerConfig | MCPRemoteServerConfig;
+
 /** Runtime configuration derived from environment variables. */
-export type Config = z.infer<typeof configSchema>;
+export type Config = Omit<z.infer<typeof configSchema>, "mcpConfigPath"> & {
+  mcpServers: Record<string, MCPServerConfig>;
+};
 
 function parseEnvFile(filePath: string): Record<string, string> {
   const vars: Record<string, string> = {};
@@ -45,6 +69,39 @@ function getEnv(key: string, envFile: Record<string, string>): string | undefine
   return process.env[key] || envFile[key] || undefined;
 }
 
+/**
+ * Load MCP server configurations from a JSON file.
+ * Supports both the native Copilot format `{ "mcpServers": { ... } }` and
+ * a flat `Record<string, MCPServerConfig>` object.
+ * Returns an empty object if the file does not exist.
+ */
+export function loadMcpServers(configPath: string): Record<string, MCPServerConfig> {
+  if (!existsSync(configPath)) {
+    return {};
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(configPath, "utf-8"));
+  } catch (err) {
+    throw new Error(
+      `Failed to parse MCP config at ${configPath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new Error(`MCP config at ${configPath} must be a JSON object`);
+  }
+
+  // Support native Copilot format: { "mcpServers": { ... } }
+  const obj = raw as Record<string, unknown>;
+  const servers = (typeof obj.mcpServers === "object" && obj.mcpServers !== null && !Array.isArray(obj.mcpServers))
+    ? obj.mcpServers as Record<string, MCPServerConfig>
+    : obj as Record<string, MCPServerConfig>;
+
+  return servers;
+}
+
 /** Load configuration from environment variables and optional .env file. */
 export function loadConfig(cwd: string = process.cwd()): Config {
   const envFilePath = resolve(cwd, ".env");
@@ -62,14 +119,29 @@ export function loadConfig(cwd: string = process.cwd()): Config {
       getEnv("CRON_ENABLED", envFile) === "true" ||
       getEnv("CRON_ENABLED", envFile) === "1",
     logLevel: getEnv("LOG_LEVEL", envFile) ?? "info",
+    mcpConfigPath: getEnv("MCP_CONFIG_PATH", envFile),
   };
 
-  const config = configSchema.parse(raw);
+  const parsed = configSchema.parse(raw);
 
   // At least one channel must be configured
-  if (!config.telegramBotToken && !config.slackBotToken) {
+  if (!parsed.telegramBotToken && !parsed.slackBotToken) {
     throw new Error("At least one channel must be configured: set TELEGRAM_BOT_TOKEN and/or SLACK_BOT_TOKEN + SLACK_APP_TOKEN");
   }
 
-  return config;
+  // Load MCP server configs from file
+  const mcpPath = parsed.mcpConfigPath
+    ? resolve(cwd, parsed.mcpConfigPath)
+    : resolve(cwd, "mcp-servers.json");
+  const mcpServers = loadMcpServers(mcpPath);
+
+  const serverCount = Object.keys(mcpServers).length;
+  if (serverCount > 0) {
+    console.log(`[config] Loaded ${serverCount} MCP server(s) from ${mcpPath}`);
+  } else if (parsed.mcpConfigPath) {
+    console.warn(`[config] MCP config path set but no servers loaded from ${mcpPath}`);
+  }
+
+  const { mcpConfigPath: _, ...rest } = parsed;
+  return { ...rest, mcpServers };
 }

--- a/src/sessions/manager.test.ts
+++ b/src/sessions/manager.test.ts
@@ -67,6 +67,7 @@ const baseConfig: Config = {
   cliPort: undefined,
   cronEnabled: false,
   logLevel: "info",
+  mcpServers: {},
 };
 
 const createChannel = (): MessagingChannel => ({
@@ -173,6 +174,109 @@ describe("SessionManager", () => {
     await manager.endSession("chat-4");
     expect(internals.sessionMap.has("session-a")).toBe(false);
     expect(internals.attachedSessions.has("session-a")).toBe(false);
+
+    await manager.stop();
+  });
+
+  it("passes mcpServers to createSession when configured", async () => {
+    const mcpConfig: Config = {
+      ...baseConfig,
+      mcpServers: {
+        exa: { tools: ["*"], type: "http" as const, url: "https://mcp.exa.ai/mcp" },
+      },
+    };
+    const channel = createChannel();
+    const manager = new SessionManager(mcpConfig, channel);
+    await manager.start();
+
+    await manager.createSession("chat-mcp");
+
+    const client = (manager as unknown as { client: { createSession: ReturnType<typeof vi.fn> } }).client;
+    expect(client.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mcpServers: { exa: { tools: ["*"], type: "http", url: "https://mcp.exa.ai/mcp" } },
+      }),
+    );
+
+    await manager.stop();
+  });
+
+  it("passes mcpServers to resumeSession on named session", async () => {
+    const mcpConfig: Config = {
+      ...baseConfig,
+      mcpServers: {
+        mslearn: { tools: ["*"], type: "http" as const, url: "https://learn.microsoft.com/api/mcp" },
+      },
+    };
+    const channel = createChannel();
+    const manager = new SessionManager(mcpConfig, channel);
+    await manager.start();
+
+    // Named session triggers resume path (which fails, then falls back to create)
+    const client = (manager as unknown as { client: { resumeFailures: Set<string> } }).client;
+    client.resumeFailures.add("named-mcp");
+    await manager.createSession("chat-mcp2", "named-mcp");
+
+    const clientFull = (manager as unknown as { client: { resumeSession: ReturnType<typeof vi.fn>; createSession: ReturnType<typeof vi.fn> } }).client;
+    // Resume was attempted with mcpServers
+    expect(clientFull.resumeSession).toHaveBeenCalledWith(
+      "named-mcp",
+      expect.objectContaining({
+        mcpServers: { mslearn: { tools: ["*"], type: "http", url: "https://learn.microsoft.com/api/mcp" } },
+      }),
+    );
+    // Fallback create also includes mcpServers
+    expect(clientFull.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mcpServers: { mslearn: { tools: ["*"], type: "http", url: "https://learn.microsoft.com/api/mcp" } },
+      }),
+    );
+
+    await manager.stop();
+  });
+
+  it("passes mcpServers to resumeSession on switchSession", async () => {
+    const mcpConfig: Config = {
+      ...baseConfig,
+      mcpServers: {
+        exa: { tools: ["*"], type: "http" as const, url: "https://mcp.exa.ai/mcp" },
+      },
+    };
+    const channel = createChannel();
+    const manager = new SessionManager(mcpConfig, channel);
+    await manager.start();
+
+    await manager.createSession("chat-switch", "switch-session");
+    const internals = manager as unknown as {
+      sessionMap: Map<string, unknown>;
+      attachedSessions: Set<string>;
+    };
+    internals.sessionMap.delete("switch-session");
+    internals.attachedSessions.delete("switch-session");
+
+    await manager.switchSession("chat-switch", 1);
+
+    const clientFull = (manager as unknown as { client: { resumeSession: ReturnType<typeof vi.fn> } }).client;
+    expect(clientFull.resumeSession).toHaveBeenCalledWith(
+      "switch-session",
+      expect.objectContaining({
+        mcpServers: { exa: { tools: ["*"], type: "http", url: "https://mcp.exa.ai/mcp" } },
+      }),
+    );
+
+    await manager.stop();
+  });
+
+  it("omits mcpServers when config is empty", async () => {
+    const channel = createChannel();
+    const manager = new SessionManager(baseConfig, channel);
+    await manager.start();
+
+    await manager.createSession("chat-nomcp");
+
+    const client = (manager as unknown as { client: { createSession: ReturnType<typeof vi.fn> } }).client;
+    const callArgs = client.createSession.mock.calls[0][0];
+    expect(callArgs.mcpServers).toBeUndefined();
 
     await manager.stop();
   });

--- a/src/sessions/manager.ts
+++ b/src/sessions/manager.ts
@@ -102,6 +102,10 @@ export class SessionManager {
     let session: CopilotSession;
     const sessionHooks = this.buildSessionHooks();
 
+    const mcpServers = Object.keys(this.config.mcpServers).length > 0
+      ? this.config.mcpServers
+      : undefined;
+
     if (customSessionId && this.sessionMap.has(sessionId)) {
       session = this.sessionMap.get(sessionId)!;
     } else if (customSessionId) {
@@ -109,6 +113,7 @@ export class SessionManager {
         session = await client.resumeSession(sessionId, {
           onPermissionRequest: approveAll,
           hooks: sessionHooks,
+          mcpServers,
         });
       } catch (resumeErr) {
         console.warn(`[session-manager] Could not resume session ${sessionId}, creating new:`, resumeErr);
@@ -116,6 +121,7 @@ export class SessionManager {
           sessionId,
           onPermissionRequest: approveAll,
           hooks: sessionHooks,
+          mcpServers,
           infiniteSessions: {
             enabled: true,
             backgroundCompactionThreshold: 0.8,
@@ -128,6 +134,7 @@ export class SessionManager {
         sessionId,
         onPermissionRequest: approveAll,
         hooks: sessionHooks,
+        mcpServers,
         infiniteSessions: {
           enabled: true,
           backgroundCompactionThreshold: 0.8,
@@ -237,9 +244,13 @@ export class SessionManager {
     // Resume if not already active
     if (!this.sessionMap.has(target.sessionId)) {
       const client = this.ensureClient();
+      const mcpServers = Object.keys(this.config.mcpServers).length > 0
+        ? this.config.mcpServers
+        : undefined;
       const session = await client.resumeSession(target.sessionId, {
         onPermissionRequest: approveAll,
         hooks: this.buildSessionHooks(),
+        mcpServers,
       });
       this.sessionMap.set(target.sessionId, session);
       this.attachSessionHandlers(session, chatId, target.sessionId);


### PR DESCRIPTION
## Summary

Fixes #3 — MCP tools (Exa, Perplexity, MS Learn, YouTube, etc.) were missing from bridge sessions because \mcpServers\ was never passed to the CopilotClient SDK.

## Changes

- **\src/config.ts\** — Added \loadMcpServers()\ supporting both native Copilot format (\{ mcpServers: { ... } }\) and flat format. New \MCP_CONFIG_PATH\ env var (defaults to \./mcp-servers.json\).
- **\src/sessions/manager.ts\** — Passes \mcpServers\ to all 4 session creation/resume paths.
- **\mcp-servers.json.example\** — Template with common MCP server configs.
- **11 new tests** — All 70 tests passing ✅

## Usage

Copy \mcp-servers.json.example\ → \mcp-servers.json\ and fill in API keys. On the sandbox, set \MCP_CONFIG_PATH=~/.copilot/mcp-config.json\ to use the existing native config.

Closes #3